### PR TITLE
Add support for :export and :import selectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+  * Added support for `:export` and `:import()` selectors.
+
 ### Changed
   * Only support Stylelint 11 onwards.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Changed
+  * Only support Stylelint 11 onwards.
 
 ## [1.5.0] - 2019-09-16
 ### Added

--- a/README.md
+++ b/README.md
@@ -61,66 +61,10 @@ yarn add stylelint-config-css-modules --dev
 :global(.js) .progressive {
   display: block;
 }
-```
 
-## Dealing with `:export` variables
-
-> A couple of available solutions, pick your poison
-
-#### 1. Inline comments
-
-```css
 :export {
-  /* stylelint-disable property-no-unknown */
   black: #000;
   white: #111;
-  /* stylelint-enable */
-}
-```
-
-#### 2. Prefixed names
-
-```css
-:export {
-  $black: #000;
-  $white: #111;
-}
-```
-
-#### 3. Config whitelist
-
-```json
-{
-  "rules": {
-    "property-no-unknown": [
-      true,
-      {
-        "ignoreProperties": ["black", "white"]
-      }
-    ]
-  }
-}
-```
-
-#### 4. Custom prefix
-
-```css
-:export {
-  foo-black: #000;
-  foo-white: #111;
-}
-```
-
-```json
-{
-  "rules": {
-    "property-no-unknown": [
-      true,
-      {
-        "ignoreProperties": ["/^foo/"]
-      }
-    ]
-  }
 }
 ```
 

--- a/index.js
+++ b/index.js
@@ -22,6 +22,7 @@ module.exports = {
       true,
       {
         ignoreProperties: ['composes', 'compose-with'],
+        ignoreSelectors: [':export', /^:import/],
       },
     ],
     'at-rule-no-unknown': [

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "devDependencies": {
     "ava": "^2.4.0",
-    "stylelint": "11.0.0",
+    "stylelint": "^11.0.0",
     "stylelint-config-standard": "^19.0.0"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -30,10 +30,10 @@
   },
   "devDependencies": {
     "ava": "^2.4.0",
-    "stylelint": "^11.0.0",
+    "stylelint": "11.0.0",
     "stylelint-config-standard": "^19.0.0"
   },
   "peerDependencies": {
-    "stylelint": "7.x - 11.x"
+    "stylelint": "11.x"
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -41,10 +41,12 @@ const code = `
 }
 
 :export {
-  /* stylelint-disable property-no-unknown */
   black: #000;
   white: #111;
-  /* stylelint-enable */
+}
+
+:import("./path/to/file.css") {
+  alias: keyFromFile;
 }
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -3783,7 +3783,7 @@ stylelint-config-standard@^19.0.0:
   dependencies:
     stylelint-config-recommended "^3.0.0"
 
-stylelint@11.0.0:
+stylelint@^11.0.0:
   version "11.0.0"
   resolved "https://registry.yarnpkg.com/stylelint/-/stylelint-11.0.0.tgz#1458d1e126d4f2fb9f41076197f852aa1fcae91d"
   integrity sha512-esKkG7CUXI5yr4jgCNuwjiiV6NJ4BpodB0e47oFvUBaHgpiXXHRPOajpb0IXL7Ucpk+X3dcrlPxVHpmJ5XUDwg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -3783,7 +3783,7 @@ stylelint-config-standard@^19.0.0:
   dependencies:
     stylelint-config-recommended "^3.0.0"
 
-stylelint@^11.0.0:
+stylelint@11.0.0:
   version "11.0.0"
   resolved "https://registry.yarnpkg.com/stylelint/-/stylelint-11.0.0.tgz#1458d1e126d4f2fb9f41076197f852aa1fcae91d"
   integrity sha512-esKkG7CUXI5yr4jgCNuwjiiV6NJ4BpodB0e47oFvUBaHgpiXXHRPOajpb0IXL7Ucpk+X3dcrlPxVHpmJ5XUDwg==


### PR DESCRIPTION
There have been a [couple](https://github.com/pascalduez/stylelint-config-css-modules/issues/3) of [issues](https://github.com/pascalduez/stylelint-config-css-modules/issues/4) raised on this repo to support whitelisting properties in `:export` selectors. I think the solutions offered there are work-arounds and miss the point: it doesn't make sense to compare properties in an `:export` block against a whitelist of known CSS properties when the [ICSS spec](https://github.com/css-modules/icss#export) allows all properties nested in `:export` to be arbitrary. At the time the issues were raised, stylelint didn't support arbitrary whitelisting of properties under a given selector. Since then, I've added the [ignoreSelectors](https://stylelint.io/user-guide/rules/property-no-unknown#ignoreselectors-regex-regex-string) option, which was released in stylelint@11. 

This PR adds configuration to skip `property-no-unknown` checks on `:export` and `:import` selectors. This should prevent a CSS modules user from needing any `/* stylelint-disable */` comments or whitelisted variable names to use the `:export` syntax. The downside of this is that the config will only be valid in stylelint v11 onwards, which means the peerDependencies need restricting. This makes this change backwards-incompatible, and should come with a new major release.