### PR TITLE
Disable case value-keyword-case for composes

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,6 +37,12 @@ export default {
         ignoreFunctions: ['global'],
       },
     ],
+    'value-keyword-case': [
+      'lower',
+      {
+        ignoreProperties: ['composes', 'compose-with'],
+      },
+    ],
   },
   overrides: [
     {

--- a/test/fixtures.css
+++ b/test/fixtures.css
@@ -2,14 +2,25 @@
 @value colors: "./colors.css";
 @value primary, secondary from colors;
 @value small as bp-small, large as bp-large from "./breakpoints.css";
+@value someValue: orange;
 
 .base {
   content: "base";
-  color: grey;
+}
+
+/* stylelint-disable-next-line selector-class-pattern */
+.camelCase {
+  content: "camel";
+}
+
+.kebab-case {
+  content: "kebab";
 }
 
 .composed {
   composes: base;
+  composes: camelCase;
+  composes: kebab-case;
 }
 
 .composed-with {


### PR DESCRIPTION
See #7, #13

Just checking what it takes, whether it make sense or not.

While this "solves" the issue with classes used with `composes`. This does not solve the one with `@value`.
```css
@value camelCase: green;
a { color: camelCase } /* error */
```
Since `@value` can be used in a wide range of properties, we don't have much solutions here.

Also we can see that disabling `selector-class-pattern` was necessary locally.   
The CSS modules spec don't enforce a particular case, so this config won't disable `selector-class-pattern`. It's out of scope.

The whole benefit of this change is quite debatable, some per projects overrides will always be needed.    
One would still need to:
- disable `selector-class-pattern` locally
- change case for `@value` or build a unmaintainable list of ignored properties

