### PR TITLE
Ignore `custom-elements` for `selector-type-no-unknown`

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,6 +15,7 @@ export default {
     'selector-type-no-unknown': [
       true,
       {
+        ignore: ["custom-elements"],
         ignoreTypes: ['from'],
       },
     ],


### PR DESCRIPTION
This PR brings the ruleset into consistency with the official base `stylelint-config-recommended` ruleset, which ignores `custom-elements`:

https://github.com/stylelint/stylelint-config-recommended/blob/f862a67da107449c3e7ccc8ffd034fb28dd789af/index.js#L47C14-L47C31

If `stylelint-config-css-modules` is used in conjunction, it overrides that base rule, dropping the ignoring of `custom-elements`, in turn requiring a local override to bring it back. Since there's no reason to differ from the standard ruleset to support CSS modules, it's best to align.