### PR TITLE
Remove function-no-unknown overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+  * Remove `function-no-unknown` overrides since that rule is not part
+    of `stylelint-config-standard` nor `stylelint-config-standard-scss`
+    anymore.
+
 ## [4.4.1] - 2025-06-20
 ### Fixed
   * Update `selector-type-no-unknown` to match default configuration of

--- a/index.js
+++ b/index.js
@@ -32,12 +32,6 @@ export default {
         ignoreAtRules: ['value'],
       },
     ],
-    'function-no-unknown': [
-      true,
-      {
-        ignoreFunctions: ['global'],
-      },
-    ],
   },
   overrides: [
     {
@@ -49,13 +43,6 @@ export default {
           true,
           {
             ignoreAtRules: ['value'],
-          },
-        ],
-        'function-no-unknown': null,
-        'scss/function-no-unknown': [
-          true,
-          {
-            ignoreFunctions: ['global'],
           },
         ],
       },


### PR DESCRIPTION
`function-no-unknown` was removed from `stylelint-config-standard` and `stylelint-config-standard-scss`.   

* See https://github.com/stylelint/stylelint-config-recommended/releases/tag/15.0.0  
* See https://github.com/stylelint-scss/stylelint-config-recommended-scss/releases/tag/v6.0.0  