### PR TITLE
Override `at-rule-empty-line-before` from `stylelint-config-standard` to ignore `@value` at rules

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -1,3 +1,9 @@
 {
-  "extends": ["stylelint-config-standard", "./index.js"]
+  "extends": ["stylelint-config-standard", "./index.js"],
+  "overrides": [
+    {
+      "files": "**/*.scss",
+      "extends": ["stylelint-config-standard-scss", "./index.js"]
+    }
+  ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+  * Override `at-rule-empty-line-before` from `stylelint-config-standard` to
+    ignore `@value` at rules.
 
 ### Fixed
   * Remove `function-no-unknown` overrides since that rule is not part

--- a/index.js
+++ b/index.js
@@ -32,6 +32,14 @@ export default {
         ignoreAtRules: ['value'],
       },
     ],
+    'at-rule-empty-line-before': [
+      'always',
+      {
+        except: ['blockless-after-same-name-blockless', 'first-nested'],
+        ignore: ['after-comment'],
+        ignoreAtRules: ['value'],
+      },
+    ],
   },
   overrides: [
     {

--- a/test/scss.js
+++ b/test/scss.js
@@ -5,7 +5,7 @@ import stylelint from 'stylelint';
 
 const config = {
   extends: [
-    'stylelint-config-standard',
+    'stylelint-config-standard-scss',
     path.join(import.meta.dirname, '..', 'index.js'),
   ],
 };


### PR DESCRIPTION
We want to relax that rule for `@value`, in its current state, it forces us to group `@value` and `@use` (SCSS) for instance.   