### PR TITLE
Override `at-rule-empty-line-before` from `stylelint-config-standard` to ignore `@else`

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,7 +37,7 @@ export default {
       {
         except: ['blockless-after-same-name-blockless', 'first-nested'],
         ignore: ['after-comment'],
-        ignoreAtRules: ['value'],
+        ignoreAtRules: ['value', 'else'],
       },
     ],
   },

--- a/test/fixtures.scss
+++ b/test/fixtures.scss
@@ -12,4 +12,10 @@
 
 .test {
   content: math.div(42, 5);
+
+  @if true {
+    color: red;
+  } @else {
+    color: blue;
+  }
 }


### PR DESCRIPTION
`@if`/`@else` in Sass is typically written in a way that errors without this fix.