### PR TITLE
Overrides at-rule-empty-line-before specificaly for SCSS

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,7 +37,7 @@ export default {
       {
         except: ['blockless-after-same-name-blockless', 'first-nested'],
         ignore: ['after-comment'],
-        ignoreAtRules: ['value', 'else'],
+        ignoreAtRules: ['value'],
       },
     ],
   },
@@ -51,6 +51,14 @@ export default {
           true,
           {
             ignoreAtRules: ['value'],
+          },
+        ],
+        'at-rule-empty-line-before': [
+          'always',
+          {
+            except: ['blockless-after-blockless', 'first-nested'],
+            ignore: ['after-comment'],
+            ignoreAtRules: ['else', 'value'],
           },
         ],
       },


### PR DESCRIPTION
Following of #24, fix of #23.

The rule in [stylelint-config-standard-scss](https://github.com/stylelint-scss/stylelint-config-standard-scss/blob/f6dfec8ef432a363984e1b3fed4db417328083e3/index.js#L6) is slightly different than the one in stylelint-config-standard-css. I will correct this.
Basically if one is using Sass they should extend `stylelint-config-standard-scss` not `stylelint-config-standard-css`.